### PR TITLE
fix(module-0-activity-encode-number-list): refacter code

### DIFF
--- a/module-0-activity-encode-number-list/main.go
+++ b/module-0-activity-encode-number-list/main.go
@@ -12,24 +12,22 @@ func s(num int) []int {
 		ans = strconv.Itoa((num % 2)) + ans
 		num /= 2
 	}
-	a := make([]int, 0)
-	for _, v := range string([]rune(ans)[1:]) {
+
+	a := make([]int, len(ans)-1)
+	for i, v := range string([]rune(ans)[1:]) {
 		s, _ := strconv.Atoi(string(v))
-		a = append(a, s)
+		a[i] = s
 	}
 	return a
 }
 
 func f(c int) [][]int {
-	matrix := make([][]int, 0, c)
-	for i := range matrix {
-		matrix[i] = make([]int, 0, c)
-	}
+	matrix := make([][]int, c+1)
 
-	matrix = append(matrix, []int{})
+	matrix[0] = []int{}
 	if c > 0 {
 		for i := 1; i <= c; i++ {
-			matrix = append(matrix, s(i))
+			matrix[i] = s(i)
 		}
 	}
 	return matrix


### PR DESCRIPTION
## before

```
❯ go test ./... -v -cover -race -bench . -benchmem
=== RUN   TestF
=== RUN   TestF/1
=== RUN   TestF/2
--- PASS: TestF (0.00s)
    --- PASS: TestF/1 (0.00s)
    --- PASS: TestF/2 (0.00s)
=== RUN   Example_main
--- PASS: Example_main (0.00s)
goos: darwin
goarch: amd64
pkg: github.com/lupinthe14th/golang-getting-started/module-0-activity-encode-number-list
BenchmarkF-4       10000          28092430 ns/op         1945051 B/op      77573 allocs/op
PASS
coverage: 94.7% of statements
ok      github.com/lupinthe14th/golang-getting-started/module-0-activity-encode-number-list     282.307s
```

## after

```
❯ go test ./... -v -cover -race -bench . -benchmem
=== RUN   TestF
=== RUN   TestF/1
=== RUN   TestF/2
--- PASS: TestF (0.00s)
    --- PASS: TestF/1 (0.00s)
    --- PASS: TestF/2 (0.00s)
=== RUN   Example_main
--- PASS: Example_main (0.00s)
goos: darwin
goarch: amd64
pkg: github.com/lupinthe14th/golang-getting-started/module-0-activity-encode-number-list
BenchmarkF-4       10000          19512478 ns/op         1021140 B/op      58109 allocs/op
PASS
coverage: 100.0% of statements
ok      github.com/lupinthe14th/golang-getting-started/module-0-activity-encode-number-list     196.218s
```